### PR TITLE
Tidy generated HTML layout for readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>ML & Algotrading Wiki</title>
+<title>ML, Trading & Algotrading Wiki</title>
 <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>
 <input type="checkbox" id="theme-toggle">
 <div class="wrapper">
 <header class="top-bar">
-  <h1 class="site-title"><a href="#home">ML & Algotrading Wiki</a></h1>
+  <h1 class="site-title"><a href="#home">ML, Trading & Algotrading Wiki</a></h1>
   <div class="controls">
 <details class="language">
   <summary>EN</summary>
@@ -22,68 +22,445 @@
 <div class="main">
 <nav class="sidebar">
 <ul>
-<li><a href="#home">Home</a></li>
-<li><a href="#intro">Introduction</a></li>
-<li><a href="#ml-vs-hardcoded">ML vs Hardcoded</a></li>
-<li><a href="#strategy-comparisons">Strategy Comparisons</a></li>
-<li><a href="#indicators">Indicators</a></li>
-<li><a href="#how-to-deploy">How to Deploy</a></li>
-<li><a href="#glossary">Glossary</a></li>
-<li><a href="#tags">Tags</a></li>
+  <li><a href="#home">Home</a></li>
+  <li><a href="#intro">Introduction</a></li>
+  <li><a href="#ml-vs-hardcoded">ML vs Hardcoded</a></li>
+  <li><a href="#strategy-comparisons">Strategy Comparisons</a></li>
+  <li><a href="#indicators">Indicators</a></li>
+  <li><a href="#how-to-deploy">How to Deploy</a></li>
+  <li><a href="#glossary">Glossary</a></li>
+  <li><a href="#tags">Tags</a></li>
 </ul>
 </nav>
 <main class="content">
-<section id="home"><h2>ML & Algotrading Wiki</h2><p>Welcome to a plain collection of notes on machine learning, algorithmic trading, and technical automation. Start with the <a href="#intro">Introduction</a> or jump to the <a href="#glossary">Glossary</a>.</p></section>
-<section id="intro"><h2>Introduction</h2><p>Overview of the project's purpose and how to navigate the pages. For terminology see <a href="#indicators">Indicators</a>.</p></section>
-<section id="ml-vs-hardcoded"><h2>ML vs Hardcoded</h2><p>Distinction between data-driven models and apps built on fixed rule sets. Compare approaches in <a href="#strategy-comparisons">Strategy Comparisons</a>.</p></section>
-<section id="strategy-comparisons"><h2>Strategy Comparisons</h2><p>Notes on comparing simple trading strategies and calibration approaches. Learn more about building blocks in <a href="#indicators">Indicators</a>.</p></section>
-<section id="indicators"><h2>Indicators</h2><p>Terminology notes: indicator vs indykator vs oscillator. Revisit the basics in <a href="#intro">Introduction</a>.</p></section>
-<section id="how-to-deploy"><h2>How to Deploy</h2><p>Step-by-step notes on setting up and running an Algorading Web App. Before deployment, review <a href="#strategy-comparisons">Strategy Comparisons</a>.</p></section>
-<section id="glossary"><h2>Glossary</h2><h3>Basic Indicators and Metrics</h3><dl>
-<dt id='rsi'>RSI</dt><dd>Oscillator measuring trend strength (overbought/oversold). <span class='tags'>#indicator #oscillator</span><br><span class='code'>Coded as: RSI</span></dd>
-<dt id='macd'>MACD</dt><dd>Moving average convergence divergence based on differences between <a href='#ma'>MA</a>s. <span class='tags'>#indicator #trend</span><br><span class='code'>Coded as: MACD</span></dd>
-<dt id='sma'>SMA</dt><dd>Simple moving average; a basic <a href='#ma'>MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: SMA</span></dd>
-<dt id='ema'>EMA</dt><dd>Exponential moving average; weighted <a href='#ma'>MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: EMA</span></dd>
-<dt id='ma'>MA</dt><dd>General moving average; basis for <a href='#macd'>MACD</a> and <a href='#sma'>SMA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: MA</span></dd>
-<dt id='cagr'>CAGR</dt><dd>Compound annual growth rate. <span class='tags'>#metric #return</span><br><span class='code'>Coded as: CAGR</span></dd>
-<dt id='sharpe'>Sharpe Ratio</dt><dd>Return relative to volatility risk. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: SharpeRatio</span></dd>
-<dt id='sortino'>Sortino Ratio</dt><dd>Sharpe variant considering downside risk only. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: SortinoRatio</span></dd>
-<dt id='maxdd'>Max Drawdown</dt><dd>Maximum capital drop from a peak. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: MaxDrawdown</span></dd>
-</dl><h3>Risk &amp; Money Management</h3><dl>
-<dt id='kelly'>Kelly Sizing</dt><dd>Optimal position sizing formula. <span class='tags'>#risk #position-sizing</span><br><span class='code'>Coded as: KellySizing</span></dd>
-<dt id='stop-loss'>Stop Loss</dt><dd>Order limiting loss; see also <a href='#trailing-stop'>Trailing Stop</a>. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: StopLossMain</span></dd>
-<dt id='trailing-stop'>Trailing Stop</dt><dd>Stop loss that follows price movement. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TrailingStop</span></dd>
-<dt id='take-profit'>Take Profit</dt><dd>Automatic order to lock gains. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TakeProfit</span></dd>
-<dt id='trailing-take-profit'>Trailing Take Profit</dt><dd>Take profit level moving with price. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TrailingTakeProfit</span></dd>
-<dt id='leverage'>Leverage</dt><dd>Borrowed exposure multiplier. <span class='tags'>#risk #leverage</span><br><span class='code'>Coded as: Leverage</span></dd>
-<dt id='martingale'>Martingale</dt><dd>Doubling stake after losses. <span class='tags'>#risk #strategy</span><br><span class='code'>Coded as: Martingale</span></dd>
-<dt id='delta-neutral'>Delta Neutral</dt><dd>Hedged position with no directional exposure. <span class='tags'>#risk #hedging</span><br><span class='code'>Coded as: DeltaNeutral</span></dd>
-<dt id='hedging'>Hedging</dt><dd>Risk reduction by offsetting positions. <span class='tags'>#risk #hedging</span><br><span class='code'>Coded as: Hedging</span></dd>
-</dl><h3>Instruments &amp; Markets</h3><dl>
-<dt id='spot'>Spot Market</dt><dd>Immediate asset exchange. <span class='tags'>#market #spot</span><br><span class='code'>Coded as: SpotMarket</span></dd>
-<dt id='perpetual'>Perpetual Futures</dt><dd>Futures without expiry; tied to <a href='#funding'>funding rate</a>. <span class='tags'>#market #futures</span><br><span class='code'>Coded as: PerpetualFutures</span></dd>
-<dt id='options'>Options</dt><dd>Right to buy or sell in future. <span class='tags'>#market #derivatives</span><br><span class='code'>Coded as: Options</span></dd>
-<dt id='etfs'>ETFs</dt><dd>Exchange-traded funds holding baskets of assets. <span class='tags'>#market #etf</span><br><span class='code'>Coded as: ETFs</span></dd>
-<dt id='long'>Long Position</dt><dd>Bet on price increase. <span class='tags'>#position #long</span><br><span class='code'>Coded as: LongPosition</span></dd>
-<dt id='short'>Short Position</dt><dd>Bet on price decrease. <span class='tags'>#position #short</span><br><span class='code'>Coded as: ShortPosition</span></dd>
-</dl><h3>Quant &amp; ML in Trading</h3><dl>
-<dt id='ohlcv'>OHLCV</dt><dd>Candlestick data: open, high, low, close, volume. <span class='tags'>#data #ohlcv</span><br><span class='code'>Coded as: OHLCV</span></dd>
-<dt id='lstm'>LSTM</dt><dd>Recurrent neural network for sequences. <span class='tags'>#ml #rnn</span><br><span class='code'>Coded as: LSTM</span></dd>
-<dt id='random-forest'>Random Forest</dt><dd>Ensemble of decision trees. <span class='tags'>#ml #tree</span><br><span class='code'>Coded as: RandomForest</span></dd>
-<dt id='xgboost'>XGBoost</dt><dd>Gradient boosting method. <span class='tags'>#ml #boosting</span><br><span class='code'>Coded as: XGBoost</span></dd>
-<dt id='footprint'>Footprint / CVD</dt><dd>Volume and order flow analysis. <span class='tags'>#data #volume</span><br><span class='code'>Coded as: FootprintCVD</span></dd>
-</dl><h3>Trading Styles</h3><dl>
-<dt id='scalping'>Scalping</dt><dd>Fast trades for small profits. <span class='tags'>#style #scalping</span><br><span class='code'>Coded as: Scalping</span></dd>
-<dt id='swing'>Swing Trading</dt><dd>Holding positions for days or weeks. <span class='tags'>#style #swing</span><br><span class='code'>Coded as: SwingTrading</span></dd>
-<dt id='day-trading'>Day Trading</dt><dd>Closing positions within the day. <span class='tags'>#style #day</span><br><span class='code'>Coded as: DayTrading</span></dd>
-<dt id='position-trading'>Position Trading</dt><dd>Long-term investing. <span class='tags'>#style #position</span><br><span class='code'>Coded as: PositionTrading</span></dd>
-</dl><h3>Bybit/Binance Terms</h3><dl>
-<dt id='funding'>Funding Rate</dt><dd>Payment aligning <a href='#perpetual'>perpetual futures</a> price with spot. <span class='tags'>#exchange #funding</span><br><span class='code'>Coded as: FundingRate</span></dd>
-<dt id='margin'>Margin</dt><dd>Collateral securing leveraged trades. <span class='tags'>#exchange #margin</span><br><span class='code'>Coded as: Margin</span></dd>
-<dt id='pnl'>PnL</dt><dd>Profit and loss, realized or unrealized. <span class='tags'>#exchange #pnl</span><br><span class='code'>Coded as: PnL</span></dd>
-<dt id='liquidation'>Liquidation</dt><dd>Forced closing due to insufficient <a href='#margin'>margin</a>. <span class='tags'>#exchange #liquidation</span><br><span class='code'>Coded as: Liquidation</span></dd>
-</dl></section>
-<section id="tags"><h2>Tags</h2><div id='tag-index'></div></section>
+<section id="home">
+  <h2>ML, Trading & Algotrading Wiki</h2>
+  <p>Collection of notes on machine learning, trading, algotrading and programming.
+    Start here: <a href="#intro">Subjects</a>,
+    or discover the definitions to make understanding during reading more optimised: <a href="#glossary">Definitions</a>.</p>
+</section>
+
+<section id="intro">
+  <h2>Introduction</h2>
+  <p>Overview of the project's purpose and how to navigate the pages. For terminology see <a href="#indicators">Indicators</a>.</p>
+</section>
+
+<section id="ml-vs-hardcoded">
+  <h2>ML vs Hardcoded</h2>
+  <p>Distinction between data-driven models and apps built on fixed rule sets. Compare approaches in <a href="#strategy-comparisons">Strategy Comparisons</a>.</p>
+</section>
+
+<section id="strategy-comparisons">
+  <h2>Strategy Comparisons</h2>
+  <p>Notes on comparing simple trading strategies and calibration approaches. Learn more about building blocks in <a href="#indicators">Indicators</a>.</p>
+</section>
+
+<section id="indicators">
+  <h2>Indicators</h2>
+  <p>Terminology notes: indicator vs indykator vs oscillator. Revisit the basics in <a href="#intro">Introduction</a>.</p>
+</section>
+
+<section id="how-to-deploy">
+  <h2>How to Deploy</h2>
+  <p>Step-by-step notes on setting up and running an Algorading Web App. Before deployment, review <a href="#strategy-comparisons">Strategy Comparisons</a>.</p>
+</section>
+
+<section id="glossary">
+  <h2>Glossary</h2>
+  <p>Definitions grouped by section. Use the decorative comments in the HTML source when adding fresh entries.</p>
+  
+  <!-- ############################################### -->
+  <!-- #### SECTION: Basic Indicators and Metrics #### -->
+  <!-- ############################################### -->
+  <div class='glossary-section' data-section='basic-indicators-and-metrics'>
+    <h3>Basic Indicators and Metrics</h3>
+    <dl>
+    <!-- ---------------------------- -->
+    <!-- ---- DEFINITION 01: RSI ---- -->
+    <!-- ---------------------------- -->
+    <dt id='rsi'>RSI</dt>
+    <dd>Oscillator measuring trend strength (overbought/oversold). <span class='tags'>#indicator #oscillator</span><br><span class='code'>Coded as: RSI</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ----------------------------- -->
+    <!-- ---- DEFINITION 02: MACD ---- -->
+    <!-- ----------------------------- -->
+    <dt id='macd'>MACD</dt>
+    <dd>Moving average convergence divergence based on differences between <a href="#ma">MA</a>s. <span class='tags'>#indicator #trend</span><br><span class='code'>Coded as: MACD</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------- -->
+    <!-- ---- DEFINITION 03: SMA ---- -->
+    <!-- ---------------------------- -->
+    <dt id='sma'>SMA</dt>
+    <dd>Simple moving average; a basic <a href="#ma">MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: SMA</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------- -->
+    <!-- ---- DEFINITION 04: EMA ---- -->
+    <!-- ---------------------------- -->
+    <dt id='ema'>EMA</dt>
+    <dd>Exponential moving average; weighted <a href="#ma">MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: EMA</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- --------------------------- -->
+    <!-- ---- DEFINITION 05: MA ---- -->
+    <!-- --------------------------- -->
+    <dt id='ma'>MA</dt>
+    <dd>General moving average; basis for <a href="#macd">MACD</a> and <a href="#sma">SMA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: MA</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 05 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ----------------------------- -->
+    <!-- ---- DEFINITION 06: CAGR ---- -->
+    <!-- ----------------------------- -->
+    <dt id='cagr'>CAGR</dt>
+    <dd>Compound annual growth rate. <span class='tags'>#metric #return</span><br><span class='code'>Coded as: CAGR</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 06 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------- -->
+    <!-- ---- DEFINITION 07: Sharpe Ratio ---- -->
+    <!-- ------------------------------------- -->
+    <dt id='sharpe'>Sharpe Ratio</dt>
+    <dd>Return relative to volatility risk. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: SharpeRatio</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 07 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------------- -->
+    <!-- ---- DEFINITION 08: Sortino Ratio ---- -->
+    <!-- -------------------------------------- -->
+    <dt id='sortino'>Sortino Ratio</dt>
+    <dd>Sharpe variant considering downside risk only. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: SortinoRatio</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 08 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------- -->
+    <!-- ---- DEFINITION 09: Max Drawdown ---- -->
+    <!-- ------------------------------------- -->
+    <dt id='maxdd'>Max Drawdown</dt>
+    <dd>Maximum capital drop from a peak. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: MaxDrawdown</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 09 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+  
+  <!-- ########################################## -->
+  <!-- #### SECTION: Risk & Money Management #### -->
+  <!-- ########################################## -->
+  <div class='glossary-section' data-section='risk-money-management'>
+    <h3>Risk & Money Management</h3>
+    <dl>
+    <!-- ------------------------------------- -->
+    <!-- ---- DEFINITION 01: Kelly Sizing ---- -->
+    <!-- ------------------------------------- -->
+    <dt id='kelly'>Kelly Sizing</dt>
+    <dd>Optimal position sizing formula. <span class='tags'>#risk #position-sizing</span><br><span class='code'>Coded as: KellySizing</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------------- -->
+    <!-- ---- DEFINITION 02: Stop Loss ---- -->
+    <!-- ---------------------------------- -->
+    <dt id='stop-loss'>Stop Loss</dt>
+    <dd>Order limiting loss; see also <a href="#trailing-stop">Trailing Stop</a>. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: StopLossMain</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------------- -->
+    <!-- ---- DEFINITION 03: Trailing Stop ---- -->
+    <!-- -------------------------------------- -->
+    <dt id='trailing-stop'>Trailing Stop</dt>
+    <dd>Stop loss that follows price movement. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TrailingStop</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------ -->
+    <!-- ---- DEFINITION 04: Take Profit ---- -->
+    <!-- ------------------------------------ -->
+    <dt id='take-profit'>Take Profit</dt>
+    <dd>Automatic order to lock gains. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TakeProfit</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- --------------------------------------------- -->
+    <!-- ---- DEFINITION 05: Trailing Take Profit ---- -->
+    <!-- --------------------------------------------- -->
+    <dt id='trailing-take-profit'>Trailing Take Profit</dt>
+    <dd>Take profit level moving with price. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TrailingTakeProfit</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 05 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- --------------------------------- -->
+    <!-- ---- DEFINITION 06: Leverage ---- -->
+    <!-- --------------------------------- -->
+    <dt id='leverage'>Leverage</dt>
+    <dd>Borrowed exposure multiplier. <span class='tags'>#risk #leverage</span><br><span class='code'>Coded as: Leverage</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 06 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ----------------------------------- -->
+    <!-- ---- DEFINITION 07: Martingale ---- -->
+    <!-- ----------------------------------- -->
+    <dt id='martingale'>Martingale</dt>
+    <dd>Doubling stake after losses. <span class='tags'>#risk #strategy</span><br><span class='code'>Coded as: Martingale</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 07 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------------- -->
+    <!-- ---- DEFINITION 08: Delta Neutral ---- -->
+    <!-- -------------------------------------- -->
+    <dt id='delta-neutral'>Delta Neutral</dt>
+    <dd>Hedged position with no directional exposure. <span class='tags'>#risk #hedging</span><br><span class='code'>Coded as: DeltaNeutral</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 08 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------- -->
+    <!-- ---- DEFINITION 09: Hedging ---- -->
+    <!-- -------------------------------- -->
+    <dt id='hedging'>Hedging</dt>
+    <dd>Risk reduction by offsetting positions. <span class='tags'>#risk #hedging</span><br><span class='code'>Coded as: Hedging</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 09 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+  
+  <!-- ######################################## -->
+  <!-- #### SECTION: Instruments & Markets #### -->
+  <!-- ######################################## -->
+  <div class='glossary-section' data-section='instruments-markets'>
+    <h3>Instruments & Markets</h3>
+    <dl>
+    <!-- ------------------------------------ -->
+    <!-- ---- DEFINITION 01: Spot Market ---- -->
+    <!-- ------------------------------------ -->
+    <dt id='spot'>Spot Market</dt>
+    <dd>Immediate asset exchange. <span class='tags'>#market #spot</span><br><span class='code'>Coded as: SpotMarket</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------------ -->
+    <!-- ---- DEFINITION 02: Perpetual Futures ---- -->
+    <!-- ------------------------------------------ -->
+    <dt id='perpetual'>Perpetual Futures</dt>
+    <dd>Futures without expiry; tied to <a href="#funding">funding rate</a>. <span class='tags'>#market #futures</span><br><span class='code'>Coded as: PerpetualFutures</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------- -->
+    <!-- ---- DEFINITION 03: Options ---- -->
+    <!-- -------------------------------- -->
+    <dt id='options'>Options</dt>
+    <dd>Right to buy or sell in future. <span class='tags'>#market #derivatives</span><br><span class='code'>Coded as: Options</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ----------------------------- -->
+    <!-- ---- DEFINITION 04: ETFs ---- -->
+    <!-- ----------------------------- -->
+    <dt id='etfs'>ETFs</dt>
+    <dd>Exchange-traded funds holding baskets of assets. <span class='tags'>#market #etf</span><br><span class='code'>Coded as: ETFs</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------------- -->
+    <!-- ---- DEFINITION 05: Long Position ---- -->
+    <!-- -------------------------------------- -->
+    <dt id='long'>Long Position</dt>
+    <dd>Bet on price increase. <span class='tags'>#position #long</span><br><span class='code'>Coded as: LongPosition</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 05 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- --------------------------------------- -->
+    <!-- ---- DEFINITION 06: Short Position ---- -->
+    <!-- --------------------------------------- -->
+    <dt id='short'>Short Position</dt>
+    <dd>Bet on price decrease. <span class='tags'>#position #short</span><br><span class='code'>Coded as: ShortPosition</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 06 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+  
+  <!-- ######################################## -->
+  <!-- #### SECTION: Quant & ML in Trading #### -->
+  <!-- ######################################## -->
+  <div class='glossary-section' data-section='quant-ml-in-trading'>
+    <h3>Quant & ML in Trading</h3>
+    <dl>
+    <!-- ------------------------------ -->
+    <!-- ---- DEFINITION 01: OHLCV ---- -->
+    <!-- ------------------------------ -->
+    <dt id='ohlcv'>OHLCV</dt>
+    <dd>Candlestick data: open, high, low, close, volume. <span class='tags'>#data #ohlcv</span><br><span class='code'>Coded as: OHLCV</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ----------------------------- -->
+    <!-- ---- DEFINITION 02: LSTM ---- -->
+    <!-- ----------------------------- -->
+    <dt id='lstm'>LSTM</dt>
+    <dd>Recurrent neural network for sequences. <span class='tags'>#ml #rnn</span><br><span class='code'>Coded as: LSTM</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------------- -->
+    <!-- ---- DEFINITION 03: Random Forest ---- -->
+    <!-- -------------------------------------- -->
+    <dt id='random-forest'>Random Forest</dt>
+    <dd>Ensemble of decision trees. <span class='tags'>#ml #tree</span><br><span class='code'>Coded as: RandomForest</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------- -->
+    <!-- ---- DEFINITION 04: XGBoost ---- -->
+    <!-- -------------------------------- -->
+    <dt id='xgboost'>XGBoost</dt>
+    <dd>Gradient boosting method. <span class='tags'>#ml #boosting</span><br><span class='code'>Coded as: XGBoost</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------------------- -->
+    <!-- ---- DEFINITION 05: Footprint / CVD ---- -->
+    <!-- ---------------------------------------- -->
+    <dt id='footprint'>Footprint / CVD</dt>
+    <dd>Volume and order flow analysis. <span class='tags'>#data #volume</span><br><span class='code'>Coded as: FootprintCVD</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 05 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+  
+  <!-- ################################# -->
+  <!-- #### SECTION: Trading Styles #### -->
+  <!-- ################################# -->
+  <div class='glossary-section' data-section='trading-styles'>
+    <h3>Trading Styles</h3>
+    <dl>
+    <!-- --------------------------------- -->
+    <!-- ---- DEFINITION 01: Scalping ---- -->
+    <!-- --------------------------------- -->
+    <dt id='scalping'>Scalping</dt>
+    <dd>Fast trades for small profits. <span class='tags'>#style #scalping</span><br><span class='code'>Coded as: Scalping</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------------- -->
+    <!-- ---- DEFINITION 02: Swing Trading ---- -->
+    <!-- -------------------------------------- -->
+    <dt id='swing'>Swing Trading</dt>
+    <dd>Holding positions for days or weeks. <span class='tags'>#style #swing</span><br><span class='code'>Coded as: SwingTrading</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------ -->
+    <!-- ---- DEFINITION 03: Day Trading ---- -->
+    <!-- ------------------------------------ -->
+    <dt id='day-trading'>Day Trading</dt>
+    <dd>Closing positions within the day. <span class='tags'>#style #day</span><br><span class='code'>Coded as: DayTrading</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ----------------------------------------- -->
+    <!-- ---- DEFINITION 04: Position Trading ---- -->
+    <!-- ----------------------------------------- -->
+    <dt id='position-trading'>Position Trading</dt>
+    <dd>Long-term investing. <span class='tags'>#style #position</span><br><span class='code'>Coded as: PositionTrading</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+  
+  <!-- ###################################### -->
+  <!-- #### SECTION: Bybit/Binance Terms #### -->
+  <!-- ###################################### -->
+  <div class='glossary-section' data-section='bybit-binance-terms'>
+    <h3>Bybit/Binance Terms</h3>
+    <dl>
+    <!-- ------------------------------------- -->
+    <!-- ---- DEFINITION 01: Funding Rate ---- -->
+    <!-- ------------------------------------- -->
+    <dt id='funding'>Funding Rate</dt>
+    <dd>Payment aligning <a href="#perpetual">perpetual futures</a> price with spot. <span class='tags'>#exchange #funding</span><br><span class='code'>Coded as: FundingRate</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------- -->
+    <!-- ---- DEFINITION 02: Margin ---- -->
+    <!-- ------------------------------- -->
+    <dt id='margin'>Margin</dt>
+    <dd>Collateral securing leveraged trades. <span class='tags'>#exchange #margin</span><br><span class='code'>Coded as: Margin</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------- -->
+    <!-- ---- DEFINITION 03: PnL ---- -->
+    <!-- ---------------------------- -->
+    <dt id='pnl'>PnL</dt>
+    <dd>Profit and loss, realized or unrealized. <span class='tags'>#exchange #pnl</span><br><span class='code'>Coded as: PnL</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------ -->
+    <!-- ---- DEFINITION 04: Liquidation ---- -->
+    <!-- ------------------------------------ -->
+    <dt id='liquidation'>Liquidation</dt>
+    <dd>Forced closing due to insufficient <a href="#margin">margin</a>. <span class='tags'>#exchange #liquidation</span><br><span class='code'>Coded as: Liquidation</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINITION 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+</section>
+
+<section id="tags">
+  <h2>Tags</h2>
+  <div id='tag-index'></div>
+</section>
 <footer><p>Last updated: 2024</p></footer>
 </main>
 </div>

--- a/pl/index.html
+++ b/pl/index.html
@@ -2,14 +2,14 @@
 <html lang="pl">
 <head>
 <meta charset="UTF-8">
-<title>ML & Algotrading Wiki</title>
+<title>ML, Trading & Algotrading Wiki</title>
 <link rel="stylesheet" href="../styles/main.css">
 </head>
 <body>
 <input type="checkbox" id="theme-toggle">
 <div class="wrapper">
 <header class="top-bar">
-  <h1 class="site-title"><a href="#home">ML & Algotrading Wiki</a></h1>
+  <h1 class="site-title"><a href="#home">ML, Trading & Algotrading Wiki</a></h1>
   <div class="controls">
 <details class="language">
   <summary>PL</summary>
@@ -22,68 +22,445 @@
 <div class="main">
 <nav class="sidebar">
 <ul>
-<li><a href="#home">Strona główna</a></li>
-<li><a href="#intro">Wprowadzenie</a></li>
-<li><a href="#ml-vs-hardcoded">ML vs Hardcoded</a></li>
-<li><a href="#strategy-comparisons">Porównania Strategii</a></li>
-<li><a href="#indicators">Wskaźniki</a></li>
-<li><a href="#how-to-deploy">Jak Wdrożyć</a></li>
-<li><a href="#glossary">Glosariusz</a></li>
-<li><a href="#tags">Tagi</a></li>
+  <li><a href="#home">Strona główna</a></li>
+  <li><a href="#intro">Wprowadzenie</a></li>
+  <li><a href="#ml-vs-hardcoded">ML vs Hardcoded</a></li>
+  <li><a href="#strategy-comparisons">Porównania Strategii</a></li>
+  <li><a href="#indicators">Wskaźniki</a></li>
+  <li><a href="#how-to-deploy">Jak Wdrożyć</a></li>
+  <li><a href="#glossary">Glosariusz</a></li>
+  <li><a href="#tags">Tagi</a></li>
 </ul>
 </nav>
 <main class="content">
-<section id="home"><h2>ML & Algotrading Wiki</h2><p>Witamy w zbiorze surowych notatek o uczeniu maszynowym, algotradingu i automatyzacji technicznej. Zacznij od <a href="#intro">Wprowadzenia</a> lub przejdź do <a href="#glossary">Glosariusza</a>.</p></section>
-<section id="intro"><h2>Wprowadzenie</h2><p>Ogólny opis celu projektu i jak poruszać się po stronach. Zobacz także <a href="#indicators">Wskaźniki</a>.</p></section>
-<section id="ml-vs-hardcoded"><h2>ML vs Hardcoded</h2><p>Różnice między modelami opartymi na danych a aplikacjami o stałych regułach. Porównaj podejścia w <a href="#strategy-comparisons">Porównaniach Strategii</a>.</p></section>
-<section id="strategy-comparisons"><h2>Porównania Strategii</h2><p>Notatki dotyczące porównywania prostych strategii handlowych i podejść kalibracyjnych. Dowiedz się więcej o podstawach w <a href="#indicators">Wskaźnikach</a>.</p></section>
-<section id="indicators"><h2>Wskaźniki</h2><p>Uwagi terminologiczne: wskaźnik vs indykator vs oscylator. Wróć do podstaw w <a href="#intro">Wprowadzeniu</a>.</p></section>
-<section id="how-to-deploy"><h2>Jak Wdrożyć</h2><p>Kroki potrzebne do przygotowania i uruchomienia Algorading Web App. Przed wdrożeniem przejrzyj <a href="#strategy-comparisons">Porównania Strategii</a>.</p></section>
-<section id="glossary"><h2>Glosariusz</h2><h3>Podstawowe wskaźniki i metryki</h3><dl>
-<dt id='rsi'>RSI</dt><dd>Oscylator mierzący siłę trendu (wykupienie/wyprzedanie). <span class='tags'>#indicator #oscillator</span><br><span class='code'>Coded as: RSI</span></dd>
-<dt id='macd'>MACD</dt><dd>Wskaźnik oparty na różnicy <a href='#ma'>MA</a>. <span class='tags'>#indicator #trend</span><br><span class='code'>Coded as: MACD</span></dd>
-<dt id='sma'>SMA</dt><dd>Prosta średnia ruchoma, forma <a href='#ma'>MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: SMA</span></dd>
-<dt id='ema'>EMA</dt><dd>Wykładnicza średnia ruchoma, ważona <a href='#ma'>MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: EMA</span></dd>
-<dt id='ma'>MA</dt><dd>Uogólniona średnia ruchoma; baza dla <a href='#macd'>MACD</a> i <a href='#sma'>SMA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: MA</span></dd>
-<dt id='cagr'>CAGR</dt><dd>Skumulowana średnioroczna stopa zwrotu. <span class='tags'>#metric #return</span><br><span class='code'>Coded as: CAGR</span></dd>
-<dt id='sharpe'>Sharpe Ratio</dt><dd>Miara zysku względem ryzyka zmienności. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: SharpeRatio</span></dd>
-<dt id='sortino'>Sortino Ratio</dt><dd>Wariant Sharpe'a uwzględniający tylko ryzyko spadków. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: SortinoRatio</span></dd>
-<dt id='maxdd'>Max Drawdown</dt><dd>Maksymalne obsunięcie kapitału. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: MaxDrawdown</span></dd>
-</dl><h3>Zarządzanie ryzykiem i kapitałem</h3><dl>
-<dt id='kelly'>Kelly Sizing</dt><dd>Optymalny dobór wielkości pozycji. <span class='tags'>#risk #position-sizing</span><br><span class='code'>Coded as: KellySizing</span></dd>
-<dt id='stop-loss'>Stop Loss</dt><dd>Zlecenie ograniczające stratę; zobacz <a href='#trailing-stop'>Trailing Stop</a>. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: StopLossMain</span></dd>
-<dt id='trailing-stop'>Trailing Stop</dt><dd>Stop loss przesuwający się z ceną. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TrailingStop</span></dd>
-<dt id='take-profit'>Take Profit</dt><dd>Automatyczne zamknięcie pozycji na zysku. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TakeProfit</span></dd>
-<dt id='trailing-take-profit'>Trailing Take Profit</dt><dd>Take profit podążający za ceną. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TrailingTakeProfit</span></dd>
-<dt id='leverage'>Leverage</dt><dd>Dźwignia finansowa. <span class='tags'>#risk #leverage</span><br><span class='code'>Coded as: Leverage</span></dd>
-<dt id='martingale'>Martingale</dt><dd>Strategia podwajania stawki po stracie. <span class='tags'>#risk #strategy</span><br><span class='code'>Coded as: Martingale</span></dd>
-<dt id='delta-neutral'>Delta Neutral</dt><dd>Pozycja zabezpieczona przed ruchem kierunkowym. <span class='tags'>#risk #hedging</span><br><span class='code'>Coded as: DeltaNeutral</span></dd>
-<dt id='hedging'>Hedging</dt><dd>Zabezpieczenie ryzyka poprzez pozycje kompensujące. <span class='tags'>#risk #hedging</span><br><span class='code'>Coded as: Hedging</span></dd>
-</dl><h3>Instrumenty i rynki</h3><dl>
-<dt id='spot'>Rynek Spot</dt><dd>Natychmiastowa wymiana aktywów. <span class='tags'>#market #spot</span><br><span class='code'>Coded as: SpotMarket</span></dd>
-<dt id='perpetual'>Kontrakty Perpetual</dt><dd>Futures bez wygaśnięcia, powiązane z <a href='#funding'>fundingiem</a>. <span class='tags'>#market #futures</span><br><span class='code'>Coded as: PerpetualFutures</span></dd>
-<dt id='options'>Opcje</dt><dd>Prawo do kupna lub sprzedaży w przyszłości. <span class='tags'>#market #derivatives</span><br><span class='code'>Coded as: Options</span></dd>
-<dt id='etfs'>ETF-y</dt><dd>Fundusze notowane na giełdzie. <span class='tags'>#market #etf</span><br><span class='code'>Coded as: ETFs</span></dd>
-<dt id='long'>Pozycja Long</dt><dd>Zakład na wzrost ceny. <span class='tags'>#position #long</span><br><span class='code'>Coded as: LongPosition</span></dd>
-<dt id='short'>Pozycja Short</dt><dd>Zakład na spadek ceny. <span class='tags'>#position #short</span><br><span class='code'>Coded as: ShortPosition</span></dd>
-</dl><h3>Kwant i ML w tradingu</h3><dl>
-<dt id='ohlcv'>OHLCV</dt><dd>Dane świecowe: otwarcie, maksimum, minimum, zamknięcie, wolumen. <span class='tags'>#data #ohlcv</span><br><span class='code'>Coded as: OHLCV</span></dd>
-<dt id='lstm'>LSTM</dt><dd>Rekurencyjna sieć dla sekwencji czasowych. <span class='tags'>#ml #rnn</span><br><span class='code'>Coded as: LSTM</span></dd>
-<dt id='random-forest'>Random Forest</dt><dd>Metoda zespołowa drzew decyzyjnych. <span class='tags'>#ml #tree</span><br><span class='code'>Coded as: RandomForest</span></dd>
-<dt id='xgboost'>XGBoost</dt><dd>Boosting gradientowy dla danych finansowych. <span class='tags'>#ml #boosting</span><br><span class='code'>Coded as: XGBoost</span></dd>
-<dt id='footprint'>Footprint / CVD</dt><dd>Analiza wolumenu i przepływu zleceń. <span class='tags'>#data #volume</span><br><span class='code'>Coded as: FootprintCVD</span></dd>
-</dl><h3>Style handlu</h3><dl>
-<dt id='scalping'>Scalping</dt><dd>Szybkie transakcje na małych ruchach. <span class='tags'>#style #scalping</span><br><span class='code'>Coded as: Scalping</span></dd>
-<dt id='swing'>Swing Trading</dt><dd>Przetrzymywanie pozycji od dni do tygodni. <span class='tags'>#style #swing</span><br><span class='code'>Coded as: SwingTrading</span></dd>
-<dt id='day-trading'>Day Trading</dt><dd>Zamykanie pozycji w ciągu dnia. <span class='tags'>#style #day</span><br><span class='code'>Coded as: DayTrading</span></dd>
-<dt id='position-trading'>Position Trading</dt><dd>Długoterminowe inwestowanie. <span class='tags'>#style #position</span><br><span class='code'>Coded as: PositionTrading</span></dd>
-</dl><h3>Terminy specyficzne dla Bybit/Binance</h3><dl>
-<dt id='funding'>Funding Rate</dt><dd>Mechanizm wyrównujący cenę <a href='#perpetual'>perpetuals</a> do spotu. <span class='tags'>#exchange #funding</span><br><span class='code'>Coded as: FundingRate</span></dd>
-<dt id='margin'>Margin</dt><dd>Kapitał zabezpieczający pozycję. <span class='tags'>#exchange #margin</span><br><span class='code'>Coded as: Margin</span></dd>
-<dt id='pnl'>PnL</dt><dd>Zysk i strata (zrealizowana/niezrealizowana). <span class='tags'>#exchange #pnl</span><br><span class='code'>Coded as: PnL</span></dd>
-<dt id='liquidation'>Liquidacja</dt><dd>Przymusowe zamknięcie z powodu braku <a href='#margin'>marginu</a>. <span class='tags'>#exchange #liquidation</span><br><span class='code'>Coded as: Liquidation</span></dd>
-</dl></section>
-<section id="tags"><h2>Tagi</h2><div id='tag-index'></div></section>
+<section id="home">
+  <h2>ML, Trading & Algotrading Wiki</h2>
+  <p>Zbiór notatek o machine learningu, tradingu, algotradingu i programowaniu.
+    Spis treści: <a href="#intro">Tematy</a>
+    lub przejdź do definicji: <a href="#glossary">Definicje</a>.</p>
+</section>
+
+<section id="intro">
+  <h2>Wprowadzenie</h2>
+  <p>Ogólny opis celu projektu i jak poruszać się po stronach. Zobacz także <a href="#indicators">Wskaźniki</a>.</p>
+</section>
+
+<section id="ml-vs-hardcoded">
+  <h2>ML vs Hardcoded</h2>
+  <p>Różnice między modelami opartymi na danych a aplikacjami o stałych regułach. Porównaj podejścia w <a href="#strategy-comparisons">Porównaniach Strategii</a>.</p>
+</section>
+
+<section id="strategy-comparisons">
+  <h2>Porównania Strategii</h2>
+  <p>Notatki dotyczące porównywania prostych strategii handlowych i podejść kalibracyjnych. Dowiedz się więcej o podstawach w <a href="#indicators">Wskaźnikach</a>.</p>
+</section>
+
+<section id="indicators">
+  <h2>Wskaźniki</h2>
+  <p>Uwagi terminologiczne: wskaźnik vs indykator vs oscylator. Wróć do podstaw w <a href="#intro">Wprowadzeniu</a>.</p>
+</section>
+
+<section id="how-to-deploy">
+  <h2>Jak Wdrożyć</h2>
+  <p>Kroki potrzebne do przygotowania i uruchomienia Algorading Web App. Przed wdrożeniem przejrzyj <a href="#strategy-comparisons">Porównania Strategii</a>.</p>
+</section>
+
+<section id="glossary">
+  <h2>Glosariusz</h2>
+  <p>Definicje pogrupowane według sekcji. W źródle HTML znajdziesz ozdobne komentarze, które pomagają dopisywać nowe pojęcia.</p>
+  
+  <!-- ################################################ -->
+  <!-- #### SEKCJA: Podstawowe wskaźniki i metryki #### -->
+  <!-- ################################################ -->
+  <div class='glossary-section' data-section='basic-indicators-and-metrics'>
+    <h3>Podstawowe wskaźniki i metryki</h3>
+    <dl>
+    <!-- --------------------------- -->
+    <!-- ---- DEFINICJA 01: RSI ---- -->
+    <!-- --------------------------- -->
+    <dt id='rsi'>RSI</dt>
+    <dd>Oscylator mierzący siłę trendu (wykupienie/wyprzedanie). <span class='tags'>#indicator #oscillator</span><br><span class='code'>Kod w systemie: RSI</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------- -->
+    <!-- ---- DEFINICJA 02: MACD ---- -->
+    <!-- ---------------------------- -->
+    <dt id='macd'>MACD</dt>
+    <dd>Wskaźnik oparty na różnicy <a href="#ma">MA</a>. <span class='tags'>#indicator #trend</span><br><span class='code'>Kod w systemie: MACD</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- --------------------------- -->
+    <!-- ---- DEFINICJA 03: SMA ---- -->
+    <!-- --------------------------- -->
+    <dt id='sma'>SMA</dt>
+    <dd>Prosta średnia ruchoma, forma <a href="#ma">MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Kod w systemie: SMA</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- --------------------------- -->
+    <!-- ---- DEFINICJA 04: EMA ---- -->
+    <!-- --------------------------- -->
+    <dt id='ema'>EMA</dt>
+    <dd>Wykładnicza średnia ruchoma, ważona <a href="#ma">MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Kod w systemie: EMA</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------- -->
+    <!-- ---- DEFINICJA 05: MA ---- -->
+    <!-- -------------------------- -->
+    <dt id='ma'>MA</dt>
+    <dd>Uogólniona średnia ruchoma; baza dla <a href="#macd">MACD</a> i <a href="#sma">SMA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Kod w systemie: MA</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 05 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------- -->
+    <!-- ---- DEFINICJA 06: CAGR ---- -->
+    <!-- ---------------------------- -->
+    <dt id='cagr'>CAGR</dt>
+    <dd>Skumulowana średnioroczna stopa zwrotu. <span class='tags'>#metric #return</span><br><span class='code'>Kod w systemie: CAGR</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 06 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------ -->
+    <!-- ---- DEFINICJA 07: Sharpe Ratio ---- -->
+    <!-- ------------------------------------ -->
+    <dt id='sharpe'>Sharpe Ratio</dt>
+    <dd>Miara zysku względem ryzyka zmienności. <span class='tags'>#metric #risk</span><br><span class='code'>Kod w systemie: SharpeRatio</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 07 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------- -->
+    <!-- ---- DEFINICJA 08: Sortino Ratio ---- -->
+    <!-- ------------------------------------- -->
+    <dt id='sortino'>Sortino Ratio</dt>
+    <dd>Wariant Sharpe'a uwzględniający tylko ryzyko spadków. <span class='tags'>#metric #risk</span><br><span class='code'>Kod w systemie: SortinoRatio</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 08 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------ -->
+    <!-- ---- DEFINICJA 09: Max Drawdown ---- -->
+    <!-- ------------------------------------ -->
+    <dt id='maxdd'>Max Drawdown</dt>
+    <dd>Maksymalne obsunięcie kapitału. <span class='tags'>#metric #risk</span><br><span class='code'>Kod w systemie: MaxDrawdown</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 09 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+  
+  <!-- ################################################## -->
+  <!-- #### SEKCJA: Zarządzanie ryzykiem i kapitałem #### -->
+  <!-- ################################################## -->
+  <div class='glossary-section' data-section='risk-money-management'>
+    <h3>Zarządzanie ryzykiem i kapitałem</h3>
+    <dl>
+    <!-- ------------------------------------ -->
+    <!-- ---- DEFINICJA 01: Kelly Sizing ---- -->
+    <!-- ------------------------------------ -->
+    <dt id='kelly'>Kelly Sizing</dt>
+    <dd>Optymalny dobór wielkości pozycji. <span class='tags'>#risk #position-sizing</span><br><span class='code'>Kod w systemie: KellySizing</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- --------------------------------- -->
+    <!-- ---- DEFINICJA 02: Stop Loss ---- -->
+    <!-- --------------------------------- -->
+    <dt id='stop-loss'>Stop Loss</dt>
+    <dd>Zlecenie ograniczające stratę; zobacz <a href="#trailing-stop">Trailing Stop</a>. <span class='tags'>#risk #order</span><br><span class='code'>Kod w systemie: StopLossMain</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------- -->
+    <!-- ---- DEFINICJA 03: Trailing Stop ---- -->
+    <!-- ------------------------------------- -->
+    <dt id='trailing-stop'>Trailing Stop</dt>
+    <dd>Stop loss przesuwający się z ceną. <span class='tags'>#risk #order</span><br><span class='code'>Kod w systemie: TrailingStop</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ----------------------------------- -->
+    <!-- ---- DEFINICJA 04: Take Profit ---- -->
+    <!-- ----------------------------------- -->
+    <dt id='take-profit'>Take Profit</dt>
+    <dd>Automatyczne zamknięcie pozycji na zysku. <span class='tags'>#risk #order</span><br><span class='code'>Kod w systemie: TakeProfit</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------------------- -->
+    <!-- ---- DEFINICJA 05: Trailing Take Profit ---- -->
+    <!-- -------------------------------------------- -->
+    <dt id='trailing-take-profit'>Trailing Take Profit</dt>
+    <dd>Take profit podążający za ceną. <span class='tags'>#risk #order</span><br><span class='code'>Kod w systemie: TrailingTakeProfit</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 05 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- -------------------------------- -->
+    <!-- ---- DEFINICJA 06: Leverage ---- -->
+    <!-- -------------------------------- -->
+    <dt id='leverage'>Leverage</dt>
+    <dd>Dźwignia finansowa. <span class='tags'>#risk #leverage</span><br><span class='code'>Kod w systemie: Leverage</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 06 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------------- -->
+    <!-- ---- DEFINICJA 07: Martingale ---- -->
+    <!-- ---------------------------------- -->
+    <dt id='martingale'>Martingale</dt>
+    <dd>Strategia podwajania stawki po stracie. <span class='tags'>#risk #strategy</span><br><span class='code'>Kod w systemie: Martingale</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 07 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------- -->
+    <!-- ---- DEFINICJA 08: Delta Neutral ---- -->
+    <!-- ------------------------------------- -->
+    <dt id='delta-neutral'>Delta Neutral</dt>
+    <dd>Pozycja zabezpieczona przed ruchem kierunkowym. <span class='tags'>#risk #hedging</span><br><span class='code'>Kod w systemie: DeltaNeutral</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 08 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------- -->
+    <!-- ---- DEFINICJA 09: Hedging ---- -->
+    <!-- ------------------------------- -->
+    <dt id='hedging'>Hedging</dt>
+    <dd>Zabezpieczenie ryzyka poprzez pozycje kompensujące. <span class='tags'>#risk #hedging</span><br><span class='code'>Kod w systemie: Hedging</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 09 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+  
+  <!-- ##################################### -->
+  <!-- #### SEKCJA: Instrumenty i rynki #### -->
+  <!-- ##################################### -->
+  <div class='glossary-section' data-section='instruments-markets'>
+    <h3>Instrumenty i rynki</h3>
+    <dl>
+    <!-- ---------------------------------- -->
+    <!-- ---- DEFINICJA 01: Rynek Spot ---- -->
+    <!-- ---------------------------------- -->
+    <dt id='spot'>Rynek Spot</dt>
+    <dd>Natychmiastowa wymiana aktywów. <span class='tags'>#market #spot</span><br><span class='code'>Kod w systemie: SpotMarket</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------------- -->
+    <!-- ---- DEFINICJA 02: Kontrakty Perpetual ---- -->
+    <!-- ------------------------------------------- -->
+    <dt id='perpetual'>Kontrakty Perpetual</dt>
+    <dd>Futures bez wygaśnięcia, powiązane z <a href="#funding">fundingiem</a>. <span class='tags'>#market #futures</span><br><span class='code'>Kod w systemie: PerpetualFutures</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ----------------------------- -->
+    <!-- ---- DEFINICJA 03: Opcje ---- -->
+    <!-- ----------------------------- -->
+    <dt id='options'>Opcje</dt>
+    <dd>Prawo do kupna lub sprzedaży w przyszłości. <span class='tags'>#market #derivatives</span><br><span class='code'>Kod w systemie: Options</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ----------------------------- -->
+    <!-- ---- DEFINICJA 04: ETF-y ---- -->
+    <!-- ----------------------------- -->
+    <dt id='etfs'>ETF-y</dt>
+    <dd>Fundusze notowane na giełdzie. <span class='tags'>#market #etf</span><br><span class='code'>Kod w systemie: ETFs</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------ -->
+    <!-- ---- DEFINICJA 05: Pozycja Long ---- -->
+    <!-- ------------------------------------ -->
+    <dt id='long'>Pozycja Long</dt>
+    <dd>Zakład na wzrost ceny. <span class='tags'>#position #long</span><br><span class='code'>Kod w systemie: LongPosition</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 05 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------- -->
+    <!-- ---- DEFINICJA 06: Pozycja Short ---- -->
+    <!-- ------------------------------------- -->
+    <dt id='short'>Pozycja Short</dt>
+    <dd>Zakład na spadek ceny. <span class='tags'>#position #short</span><br><span class='code'>Kod w systemie: ShortPosition</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 06 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+  
+  <!-- ####################################### -->
+  <!-- #### SEKCJA: Kwant i ML w tradingu #### -->
+  <!-- ####################################### -->
+  <div class='glossary-section' data-section='quant-ml-in-trading'>
+    <h3>Kwant i ML w tradingu</h3>
+    <dl>
+    <!-- ----------------------------- -->
+    <!-- ---- DEFINICJA 01: OHLCV ---- -->
+    <!-- ----------------------------- -->
+    <dt id='ohlcv'>OHLCV</dt>
+    <dd>Dane świecowe: otwarcie, maksimum, minimum, zamknięcie, wolumen. <span class='tags'>#data #ohlcv</span><br><span class='code'>Kod w systemie: OHLCV</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------- -->
+    <!-- ---- DEFINICJA 02: LSTM ---- -->
+    <!-- ---------------------------- -->
+    <dt id='lstm'>LSTM</dt>
+    <dd>Rekurencyjna sieć dla sekwencji czasowych. <span class='tags'>#ml #rnn</span><br><span class='code'>Kod w systemie: LSTM</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------- -->
+    <!-- ---- DEFINICJA 03: Random Forest ---- -->
+    <!-- ------------------------------------- -->
+    <dt id='random-forest'>Random Forest</dt>
+    <dd>Metoda zespołowa drzew decyzyjnych. <span class='tags'>#ml #tree</span><br><span class='code'>Kod w systemie: RandomForest</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------- -->
+    <!-- ---- DEFINICJA 04: XGBoost ---- -->
+    <!-- ------------------------------- -->
+    <dt id='xgboost'>XGBoost</dt>
+    <dd>Boosting gradientowy dla danych finansowych. <span class='tags'>#ml #boosting</span><br><span class='code'>Kod w systemie: XGBoost</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- --------------------------------------- -->
+    <!-- ---- DEFINICJA 05: Footprint / CVD ---- -->
+    <!-- --------------------------------------- -->
+    <dt id='footprint'>Footprint / CVD</dt>
+    <dd>Analiza wolumenu i przepływu zleceń. <span class='tags'>#data #volume</span><br><span class='code'>Kod w systemie: FootprintCVD</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 05 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+  
+  <!-- ############################## -->
+  <!-- #### SEKCJA: Style handlu #### -->
+  <!-- ############################## -->
+  <div class='glossary-section' data-section='trading-styles'>
+    <h3>Style handlu</h3>
+    <dl>
+    <!-- -------------------------------- -->
+    <!-- ---- DEFINICJA 01: Scalping ---- -->
+    <!-- -------------------------------- -->
+    <dt id='scalping'>Scalping</dt>
+    <dd>Szybkie transakcje na małych ruchach. <span class='tags'>#style #scalping</span><br><span class='code'>Kod w systemie: Scalping</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------------- -->
+    <!-- ---- DEFINICJA 02: Swing Trading ---- -->
+    <!-- ------------------------------------- -->
+    <dt id='swing'>Swing Trading</dt>
+    <dd>Przetrzymywanie pozycji od dni do tygodni. <span class='tags'>#style #swing</span><br><span class='code'>Kod w systemie: SwingTrading</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ----------------------------------- -->
+    <!-- ---- DEFINICJA 03: Day Trading ---- -->
+    <!-- ----------------------------------- -->
+    <dt id='day-trading'>Day Trading</dt>
+    <dd>Zamykanie pozycji w ciągu dnia. <span class='tags'>#style #day</span><br><span class='code'>Kod w systemie: DayTrading</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------------------- -->
+    <!-- ---- DEFINICJA 04: Position Trading ---- -->
+    <!-- ---------------------------------------- -->
+    <dt id='position-trading'>Position Trading</dt>
+    <dd>Długoterminowe inwestowanie. <span class='tags'>#style #position</span><br><span class='code'>Kod w systemie: PositionTrading</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+  
+  <!-- ####################################################### -->
+  <!-- #### SEKCJA: Terminy specyficzne dla Bybit/Binance #### -->
+  <!-- ####################################################### -->
+  <div class='glossary-section' data-section='bybit-binance-terms'>
+    <h3>Terminy specyficzne dla Bybit/Binance</h3>
+    <dl>
+    <!-- ------------------------------------ -->
+    <!-- ---- DEFINICJA 01: Funding Rate ---- -->
+    <!-- ------------------------------------ -->
+    <dt id='funding'>Funding Rate</dt>
+    <dd>Mechanizm wyrównujący cenę <a href="#perpetual">perpetuals</a> do spotu. <span class='tags'>#exchange #funding</span><br><span class='code'>Kod w systemie: FundingRate</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 01 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ------------------------------ -->
+    <!-- ---- DEFINICJA 02: Margin ---- -->
+    <!-- ------------------------------ -->
+    <dt id='margin'>Margin</dt>
+    <dd>Kapitał zabezpieczający pozycję. <span class='tags'>#exchange #margin</span><br><span class='code'>Kod w systemie: Margin</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 02 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- --------------------------- -->
+    <!-- ---- DEFINICJA 03: PnL ---- -->
+    <!-- --------------------------- -->
+    <dt id='pnl'>PnL</dt>
+    <dd>Zysk i strata (zrealizowana/niezrealizowana). <span class='tags'>#exchange #pnl</span><br><span class='code'>Kod w systemie: PnL</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 03 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    <!-- ---------------------------------- -->
+    <!-- ---- DEFINICJA 04: Liquidacja ---- -->
+    <!-- ---------------------------------- -->
+    <dt id='liquidation'>Liquidacja</dt>
+    <dd>Przymusowe zamknięcie z powodu braku <a href="#margin">marginu</a>. <span class='tags'>#exchange #liquidation</span><br><span class='code'>Kod w systemie: Liquidation</span></dd>
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- ~~~~ END DEFINICJA 04 ~~~~ -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  
+    </dl>
+  </div>
+</section>
+
+<section id="tags">
+  <h2>Tagi</h2>
+  <div id='tag-index'></div>
+</section>
 <footer><p>Ostatnia aktualizacja: 2024</p></footer>
 </main>
 </div>

--- a/site_config.json
+++ b/site_config.json
@@ -4,8 +4,8 @@
     "pl": "ML, Trading & Algotrading Wiki"
   },
   "index_content": {
-    "en": "<p>Collection of notes on machine learning, Trading, algotading and Progtamming. Start here:<a href=\"#intro\">Subjects</a> or discover the definitions to make understanding during reading more optimised:<a href=\"#glossary\">Definitions</a>.</p>",
-    "pl": "<p>Zbiór notatek o Machine Learning, Trading, algotrading i programing, Spis Treści:<a href=\"#intro\">Subjects</a> lub <a href=\"#glossary\">Definitions</a>.</p>"
+    "en": "<p>Collection of notes on machine learning, trading, algotrading and programming.\n  Start here: <a href=\"#intro\">Subjects</a>,\n  or discover the definitions to make understanding during reading more optimised: <a href=\"#glossary\">Definitions</a>.</p>",
+    "pl": "<p>Zbiór notatek o machine learningu, tradingu, algotradingu i programowaniu.\n  Spis treści: <a href=\"#intro\">Tematy</a>\n  lub przejdź do definicji: <a href=\"#glossary\">Definicje</a>.</p>"
   },
   "pages": [
     {
@@ -70,8 +70,8 @@
         "pl": "Glosariusz"
       },
       "content": {
-        "en": "<h3>Basic Indicators and Metrics</h3><dl>\n<dt id='rsi'>RSI</dt><dd>Oscillator measuring trend strength (overbought/oversold). <span class='tags'>#indicator #oscillator</span><br><span class='code'>Coded as: RSI</span></dd>\n<dt id='macd'>MACD</dt><dd>Moving average convergence divergence based on differences between <a href='#ma'>MA</a>s. <span class='tags'>#indicator #trend</span><br><span class='code'>Coded as: MACD</span></dd>\n<dt id='sma'>SMA</dt><dd>Simple moving average; a basic <a href='#ma'>MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: SMA</span></dd>\n<dt id='ema'>EMA</dt><dd>Exponential moving average; weighted <a href='#ma'>MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: EMA</span></dd>\n<dt id='ma'>MA</dt><dd>General moving average; basis for <a href='#macd'>MACD</a> and <a href='#sma'>SMA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: MA</span></dd>\n<dt id='cagr'>CAGR</dt><dd>Compound annual growth rate. <span class='tags'>#metric #return</span><br><span class='code'>Coded as: CAGR</span></dd>\n<dt id='sharpe'>Sharpe Ratio</dt><dd>Return relative to volatility risk. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: SharpeRatio</span></dd>\n<dt id='sortino'>Sortino Ratio</dt><dd>Sharpe variant considering downside risk only. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: SortinoRatio</span></dd>\n<dt id='maxdd'>Max Drawdown</dt><dd>Maximum capital drop from a peak. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: MaxDrawdown</span></dd>\n</dl><h3>Risk &amp; Money Management</h3><dl>\n<dt id='kelly'>Kelly Sizing</dt><dd>Optimal position sizing formula. <span class='tags'>#risk #position-sizing</span><br><span class='code'>Coded as: KellySizing</span></dd>\n<dt id='stop-loss'>Stop Loss</dt><dd>Order limiting loss; see also <a href='#trailing-stop'>Trailing Stop</a>. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: StopLossMain</span></dd>\n<dt id='trailing-stop'>Trailing Stop</dt><dd>Stop loss that follows price movement. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TrailingStop</span></dd>\n<dt id='take-profit'>Take Profit</dt><dd>Automatic order to lock gains. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TakeProfit</span></dd>\n<dt id='trailing-take-profit'>Trailing Take Profit</dt><dd>Take profit level moving with price. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TrailingTakeProfit</span></dd>\n<dt id='leverage'>Leverage</dt><dd>Borrowed exposure multiplier. <span class='tags'>#risk #leverage</span><br><span class='code'>Coded as: Leverage</span></dd>\n<dt id='martingale'>Martingale</dt><dd>Doubling stake after losses. <span class='tags'>#risk #strategy</span><br><span class='code'>Coded as: Martingale</span></dd>\n<dt id='delta-neutral'>Delta Neutral</dt><dd>Hedged position with no directional exposure. <span class='tags'>#risk #hedging</span><br><span class='code'>Coded as: DeltaNeutral</span></dd>\n<dt id='hedging'>Hedging</dt><dd>Risk reduction by offsetting positions. <span class='tags'>#risk #hedging</span><br><span class='code'>Coded as: Hedging</span></dd>\n</dl><h3>Instruments &amp; Markets</h3><dl>\n<dt id='spot'>Spot Market</dt><dd>Immediate asset exchange. <span class='tags'>#market #spot</span><br><span class='code'>Coded as: SpotMarket</span></dd>\n<dt id='perpetual'>Perpetual Futures</dt><dd>Futures without expiry; tied to <a href='#funding'>funding rate</a>. <span class='tags'>#market #futures</span><br><span class='code'>Coded as: PerpetualFutures</span></dd>\n<dt id='options'>Options</dt><dd>Right to buy or sell in future. <span class='tags'>#market #derivatives</span><br><span class='code'>Coded as: Options</span></dd>\n<dt id='etfs'>ETFs</dt><dd>Exchange-traded funds holding baskets of assets. <span class='tags'>#market #etf</span><br><span class='code'>Coded as: ETFs</span></dd>\n<dt id='long'>Long Position</dt><dd>Bet on price increase. <span class='tags'>#position #long</span><br><span class='code'>Coded as: LongPosition</span></dd>\n<dt id='short'>Short Position</dt><dd>Bet on price decrease. <span class='tags'>#position #short</span><br><span class='code'>Coded as: ShortPosition</span></dd>\n</dl><h3>Quant &amp; ML in Trading</h3><dl>\n<dt id='ohlcv'>OHLCV</dt><dd>Candlestick data: open, high, low, close, volume. <span class='tags'>#data #ohlcv</span><br><span class='code'>Coded as: OHLCV</span></dd>\n<dt id='lstm'>LSTM</dt><dd>Recurrent neural network for sequences. <span class='tags'>#ml #rnn</span><br><span class='code'>Coded as: LSTM</span></dd>\n<dt id='random-forest'>Random Forest</dt><dd>Ensemble of decision trees. <span class='tags'>#ml #tree</span><br><span class='code'>Coded as: RandomForest</span></dd>\n<dt id='xgboost'>XGBoost</dt><dd>Gradient boosting method. <span class='tags'>#ml #boosting</span><br><span class='code'>Coded as: XGBoost</span></dd>\n<dt id='footprint'>Footprint / CVD</dt><dd>Volume and order flow analysis. <span class='tags'>#data #volume</span><br><span class='code'>Coded as: FootprintCVD</span></dd>\n</dl><h3>Trading Styles</h3><dl>\n<dt id='scalping'>Scalping</dt><dd>Fast trades for small profits. <span class='tags'>#style #scalping</span><br><span class='code'>Coded as: Scalping</span></dd>\n<dt id='swing'>Swing Trading</dt><dd>Holding positions for days or weeks. <span class='tags'>#style #swing</span><br><span class='code'>Coded as: SwingTrading</span></dd>\n<dt id='day-trading'>Day Trading</dt><dd>Closing positions within the day. <span class='tags'>#style #day</span><br><span class='code'>Coded as: DayTrading</span></dd>\n<dt id='position-trading'>Position Trading</dt><dd>Long-term investing. <span class='tags'>#style #position</span><br><span class='code'>Coded as: PositionTrading</span></dd>\n</dl><h3>Bybit/Binance Terms</h3><dl>\n<dt id='funding'>Funding Rate</dt><dd>Payment aligning <a href='#perpetual'>perpetual futures</a> price with spot. <span class='tags'>#exchange #funding</span><br><span class='code'>Coded as: FundingRate</span></dd>\n<dt id='margin'>Margin</dt><dd>Collateral securing leveraged trades. <span class='tags'>#exchange #margin</span><br><span class='code'>Coded as: Margin</span></dd>\n<dt id='pnl'>PnL</dt><dd>Profit and loss, realized or unrealized. <span class='tags'>#exchange #pnl</span><br><span class='code'>Coded as: PnL</span></dd>\n<dt id='liquidation'>Liquidation</dt><dd>Forced closing due to insufficient <a href='#margin'>margin</a>. <span class='tags'>#exchange #liquidation</span><br><span class='code'>Coded as: Liquidation</span></dd>\n</dl>",
-        "pl": "<h3>Podstawowe wskaźniki i metryki</h3><dl>\n<dt id='rsi'>RSI</dt><dd>Oscylator mierzący siłę trendu (wykupienie/wyprzedanie). <span class='tags'>#indicator #oscillator</span><br><span class='code'>Coded as: RSI</span></dd>\n<dt id='macd'>MACD</dt><dd>Wskaźnik oparty na różnicy <a href='#ma'>MA</a>. <span class='tags'>#indicator #trend</span><br><span class='code'>Coded as: MACD</span></dd>\n<dt id='sma'>SMA</dt><dd>Prosta średnia ruchoma, forma <a href='#ma'>MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: SMA</span></dd>\n<dt id='ema'>EMA</dt><dd>Wykładnicza średnia ruchoma, ważona <a href='#ma'>MA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: EMA</span></dd>\n<dt id='ma'>MA</dt><dd>Uogólniona średnia ruchoma; baza dla <a href='#macd'>MACD</a> i <a href='#sma'>SMA</a>. <span class='tags'>#indicator #average</span><br><span class='code'>Coded as: MA</span></dd>\n<dt id='cagr'>CAGR</dt><dd>Skumulowana średnioroczna stopa zwrotu. <span class='tags'>#metric #return</span><br><span class='code'>Coded as: CAGR</span></dd>\n<dt id='sharpe'>Sharpe Ratio</dt><dd>Miara zysku względem ryzyka zmienności. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: SharpeRatio</span></dd>\n<dt id='sortino'>Sortino Ratio</dt><dd>Wariant Sharpe'a uwzględniający tylko ryzyko spadków. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: SortinoRatio</span></dd>\n<dt id='maxdd'>Max Drawdown</dt><dd>Maksymalne obsunięcie kapitału. <span class='tags'>#metric #risk</span><br><span class='code'>Coded as: MaxDrawdown</span></dd>\n</dl><h3>Zarządzanie ryzykiem i kapitałem</h3><dl>\n<dt id='kelly'>Kelly Sizing</dt><dd>Optymalny dobór wielkości pozycji. <span class='tags'>#risk #position-sizing</span><br><span class='code'>Coded as: KellySizing</span></dd>\n<dt id='stop-loss'>Stop Loss</dt><dd>Zlecenie ograniczające stratę; zobacz <a href='#trailing-stop'>Trailing Stop</a>. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: StopLossMain</span></dd>\n<dt id='trailing-stop'>Trailing Stop</dt><dd>Stop loss przesuwający się z ceną. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TrailingStop</span></dd>\n<dt id='take-profit'>Take Profit</dt><dd>Automatyczne zamknięcie pozycji na zysku. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TakeProfit</span></dd>\n<dt id='trailing-take-profit'>Trailing Take Profit</dt><dd>Take profit podążający za ceną. <span class='tags'>#risk #order</span><br><span class='code'>Coded as: TrailingTakeProfit</span></dd>\n<dt id='leverage'>Leverage</dt><dd>Dźwignia finansowa. <span class='tags'>#risk #leverage</span><br><span class='code'>Coded as: Leverage</span></dd>\n<dt id='martingale'>Martingale</dt><dd>Strategia podwajania stawki po stracie. <span class='tags'>#risk #strategy</span><br><span class='code'>Coded as: Martingale</span></dd>\n<dt id='delta-neutral'>Delta Neutral</dt><dd>Pozycja zabezpieczona przed ruchem kierunkowym. <span class='tags'>#risk #hedging</span><br><span class='code'>Coded as: DeltaNeutral</span></dd>\n<dt id='hedging'>Hedging</dt><dd>Zabezpieczenie ryzyka poprzez pozycje kompensujące. <span class='tags'>#risk #hedging</span><br><span class='code'>Coded as: Hedging</span></dd>\n</dl><h3>Instrumenty i rynki</h3><dl>\n<dt id='spot'>Rynek Spot</dt><dd>Natychmiastowa wymiana aktywów. <span class='tags'>#market #spot</span><br><span class='code'>Coded as: SpotMarket</span></dd>\n<dt id='perpetual'>Kontrakty Perpetual</dt><dd>Futures bez wygaśnięcia, powiązane z <a href='#funding'>fundingiem</a>. <span class='tags'>#market #futures</span><br><span class='code'>Coded as: PerpetualFutures</span></dd>\n<dt id='options'>Opcje</dt><dd>Prawo do kupna lub sprzedaży w przyszłości. <span class='tags'>#market #derivatives</span><br><span class='code'>Coded as: Options</span></dd>\n<dt id='etfs'>ETF-y</dt><dd>Fundusze notowane na giełdzie. <span class='tags'>#market #etf</span><br><span class='code'>Coded as: ETFs</span></dd>\n<dt id='long'>Pozycja Long</dt><dd>Zakład na wzrost ceny. <span class='tags'>#position #long</span><br><span class='code'>Coded as: LongPosition</span></dd>\n<dt id='short'>Pozycja Short</dt><dd>Zakład na spadek ceny. <span class='tags'>#position #short</span><br><span class='code'>Coded as: ShortPosition</span></dd>\n</dl><h3>Kwant i ML w tradingu</h3><dl>\n<dt id='ohlcv'>OHLCV</dt><dd>Dane świecowe: otwarcie, maksimum, minimum, zamknięcie, wolumen. <span class='tags'>#data #ohlcv</span><br><span class='code'>Coded as: OHLCV</span></dd>\n<dt id='lstm'>LSTM</dt><dd>Rekurencyjna sieć dla sekwencji czasowych. <span class='tags'>#ml #rnn</span><br><span class='code'>Coded as: LSTM</span></dd>\n<dt id='random-forest'>Random Forest</dt><dd>Metoda zespołowa drzew decyzyjnych. <span class='tags'>#ml #tree</span><br><span class='code'>Coded as: RandomForest</span></dd>\n<dt id='xgboost'>XGBoost</dt><dd>Boosting gradientowy dla danych finansowych. <span class='tags'>#ml #boosting</span><br><span class='code'>Coded as: XGBoost</span></dd>\n<dt id='footprint'>Footprint / CVD</dt><dd>Analiza wolumenu i przepływu zleceń. <span class='tags'>#data #volume</span><br><span class='code'>Coded as: FootprintCVD</span></dd>\n</dl><h3>Style handlu</h3><dl>\n<dt id='scalping'>Scalping</dt><dd>Szybkie transakcje na małych ruchach. <span class='tags'>#style #scalping</span><br><span class='code'>Coded as: Scalping</span></dd>\n<dt id='swing'>Swing Trading</dt><dd>Przetrzymywanie pozycji od dni do tygodni. <span class='tags'>#style #swing</span><br><span class='code'>Coded as: SwingTrading</span></dd>\n<dt id='day-trading'>Day Trading</dt><dd>Zamykanie pozycji w ciągu dnia. <span class='tags'>#style #day</span><br><span class='code'>Coded as: DayTrading</span></dd>\n<dt id='position-trading'>Position Trading</dt><dd>Długoterminowe inwestowanie. <span class='tags'>#style #position</span><br><span class='code'>Coded as: PositionTrading</span></dd>\n</dl><h3>Terminy specyficzne dla Bybit/Binance</h3><dl>\n<dt id='funding'>Funding Rate</dt><dd>Mechanizm wyrównujący cenę <a href='#perpetual'>perpetuals</a> do spotu. <span class='tags'>#exchange #funding</span><br><span class='code'>Coded as: FundingRate</span></dd>\n<dt id='margin'>Margin</dt><dd>Kapitał zabezpieczający pozycję. <span class='tags'>#exchange #margin</span><br><span class='code'>Coded as: Margin</span></dd>\n<dt id='pnl'>PnL</dt><dd>Zysk i strata (zrealizowana/niezrealizowana). <span class='tags'>#exchange #pnl</span><br><span class='code'>Coded as: PnL</span></dd>\n<dt id='liquidation'>Liquidacja</dt><dd>Przymusowe zamknięcie z powodu braku <a href='#margin'>marginu</a>. <span class='tags'>#exchange #liquidation</span><br><span class='code'>Coded as: Liquidation</span></dd>\n</dl>"
+        "en": "<p>Definitions grouped by section. Use the decorative comments in the HTML source when adding fresh entries.</p>",
+        "pl": "<p>Definicje pogrupowane według sekcji. W źródle HTML znajdziesz ozdobne komentarze, które pomagają dopisywać nowe pojęcia.</p>"
       }
     },
     {
@@ -84,6 +84,654 @@
         "en": "<div id='tag-index'></div>",
         "pl": "<div id='tag-index'></div>"
       }
+    }
+  ],
+  "glossary_sections": [
+    {
+      "slug": "basic-indicators-and-metrics",
+      "title": {
+        "en": "Basic Indicators and Metrics",
+        "pl": "Podstawowe wskaźniki i metryki"
+      },
+      "items": [
+        {
+          "id": "rsi",
+          "label": {
+            "en": "RSI",
+            "pl": "RSI"
+          },
+          "description": {
+            "en": "Oscillator measuring trend strength (overbought/oversold).",
+            "pl": "Oscylator mierzący siłę trendu (wykupienie/wyprzedanie)."
+          },
+          "tags": [
+            "indicator",
+            "oscillator"
+          ],
+          "code": "RSI"
+        },
+        {
+          "id": "macd",
+          "label": {
+            "en": "MACD",
+            "pl": "MACD"
+          },
+          "description": {
+            "en": "Moving average convergence divergence based on differences between <a href=\"#ma\">MA</a>s.",
+            "pl": "Wskaźnik oparty na różnicy <a href=\"#ma\">MA</a>."
+          },
+          "tags": [
+            "indicator",
+            "trend"
+          ],
+          "code": "MACD"
+        },
+        {
+          "id": "sma",
+          "label": {
+            "en": "SMA",
+            "pl": "SMA"
+          },
+          "description": {
+            "en": "Simple moving average; a basic <a href=\"#ma\">MA</a>.",
+            "pl": "Prosta średnia ruchoma, forma <a href=\"#ma\">MA</a>."
+          },
+          "tags": [
+            "indicator",
+            "average"
+          ],
+          "code": "SMA"
+        },
+        {
+          "id": "ema",
+          "label": {
+            "en": "EMA",
+            "pl": "EMA"
+          },
+          "description": {
+            "en": "Exponential moving average; weighted <a href=\"#ma\">MA</a>.",
+            "pl": "Wykładnicza średnia ruchoma, ważona <a href=\"#ma\">MA</a>."
+          },
+          "tags": [
+            "indicator",
+            "average"
+          ],
+          "code": "EMA"
+        },
+        {
+          "id": "ma",
+          "label": {
+            "en": "MA",
+            "pl": "MA"
+          },
+          "description": {
+            "en": "General moving average; basis for <a href=\"#macd\">MACD</a> and <a href=\"#sma\">SMA</a>.",
+            "pl": "Uogólniona średnia ruchoma; baza dla <a href=\"#macd\">MACD</a> i <a href=\"#sma\">SMA</a>."
+          },
+          "tags": [
+            "indicator",
+            "average"
+          ],
+          "code": "MA"
+        },
+        {
+          "id": "cagr",
+          "label": {
+            "en": "CAGR",
+            "pl": "CAGR"
+          },
+          "description": {
+            "en": "Compound annual growth rate.",
+            "pl": "Skumulowana średnioroczna stopa zwrotu."
+          },
+          "tags": [
+            "metric",
+            "return"
+          ],
+          "code": "CAGR"
+        },
+        {
+          "id": "sharpe",
+          "label": {
+            "en": "Sharpe Ratio",
+            "pl": "Sharpe Ratio"
+          },
+          "description": {
+            "en": "Return relative to volatility risk.",
+            "pl": "Miara zysku względem ryzyka zmienności."
+          },
+          "tags": [
+            "metric",
+            "risk"
+          ],
+          "code": "SharpeRatio"
+        },
+        {
+          "id": "sortino",
+          "label": {
+            "en": "Sortino Ratio",
+            "pl": "Sortino Ratio"
+          },
+          "description": {
+            "en": "Sharpe variant considering downside risk only.",
+            "pl": "Wariant Sharpe'a uwzględniający tylko ryzyko spadków."
+          },
+          "tags": [
+            "metric",
+            "risk"
+          ],
+          "code": "SortinoRatio"
+        },
+        {
+          "id": "maxdd",
+          "label": {
+            "en": "Max Drawdown",
+            "pl": "Max Drawdown"
+          },
+          "description": {
+            "en": "Maximum capital drop from a peak.",
+            "pl": "Maksymalne obsunięcie kapitału."
+          },
+          "tags": [
+            "metric",
+            "risk"
+          ],
+          "code": "MaxDrawdown"
+        }
+      ]
+    },
+    {
+      "slug": "risk-money-management",
+      "title": {
+        "en": "Risk & Money Management",
+        "pl": "Zarządzanie ryzykiem i kapitałem"
+      },
+      "items": [
+        {
+          "id": "kelly",
+          "label": {
+            "en": "Kelly Sizing",
+            "pl": "Kelly Sizing"
+          },
+          "description": {
+            "en": "Optimal position sizing formula.",
+            "pl": "Optymalny dobór wielkości pozycji."
+          },
+          "tags": [
+            "risk",
+            "position-sizing"
+          ],
+          "code": "KellySizing"
+        },
+        {
+          "id": "stop-loss",
+          "label": {
+            "en": "Stop Loss",
+            "pl": "Stop Loss"
+          },
+          "description": {
+            "en": "Order limiting loss; see also <a href=\"#trailing-stop\">Trailing Stop</a>.",
+            "pl": "Zlecenie ograniczające stratę; zobacz <a href=\"#trailing-stop\">Trailing Stop</a>."
+          },
+          "tags": [
+            "risk",
+            "order"
+          ],
+          "code": "StopLossMain"
+        },
+        {
+          "id": "trailing-stop",
+          "label": {
+            "en": "Trailing Stop",
+            "pl": "Trailing Stop"
+          },
+          "description": {
+            "en": "Stop loss that follows price movement.",
+            "pl": "Stop loss przesuwający się z ceną."
+          },
+          "tags": [
+            "risk",
+            "order"
+          ],
+          "code": "TrailingStop"
+        },
+        {
+          "id": "take-profit",
+          "label": {
+            "en": "Take Profit",
+            "pl": "Take Profit"
+          },
+          "description": {
+            "en": "Automatic order to lock gains.",
+            "pl": "Automatyczne zamknięcie pozycji na zysku."
+          },
+          "tags": [
+            "risk",
+            "order"
+          ],
+          "code": "TakeProfit"
+        },
+        {
+          "id": "trailing-take-profit",
+          "label": {
+            "en": "Trailing Take Profit",
+            "pl": "Trailing Take Profit"
+          },
+          "description": {
+            "en": "Take profit level moving with price.",
+            "pl": "Take profit podążający za ceną."
+          },
+          "tags": [
+            "risk",
+            "order"
+          ],
+          "code": "TrailingTakeProfit"
+        },
+        {
+          "id": "leverage",
+          "label": {
+            "en": "Leverage",
+            "pl": "Leverage"
+          },
+          "description": {
+            "en": "Borrowed exposure multiplier.",
+            "pl": "Dźwignia finansowa."
+          },
+          "tags": [
+            "risk",
+            "leverage"
+          ],
+          "code": "Leverage"
+        },
+        {
+          "id": "martingale",
+          "label": {
+            "en": "Martingale",
+            "pl": "Martingale"
+          },
+          "description": {
+            "en": "Doubling stake after losses.",
+            "pl": "Strategia podwajania stawki po stracie."
+          },
+          "tags": [
+            "risk",
+            "strategy"
+          ],
+          "code": "Martingale"
+        },
+        {
+          "id": "delta-neutral",
+          "label": {
+            "en": "Delta Neutral",
+            "pl": "Delta Neutral"
+          },
+          "description": {
+            "en": "Hedged position with no directional exposure.",
+            "pl": "Pozycja zabezpieczona przed ruchem kierunkowym."
+          },
+          "tags": [
+            "risk",
+            "hedging"
+          ],
+          "code": "DeltaNeutral"
+        },
+        {
+          "id": "hedging",
+          "label": {
+            "en": "Hedging",
+            "pl": "Hedging"
+          },
+          "description": {
+            "en": "Risk reduction by offsetting positions.",
+            "pl": "Zabezpieczenie ryzyka poprzez pozycje kompensujące."
+          },
+          "tags": [
+            "risk",
+            "hedging"
+          ],
+          "code": "Hedging"
+        }
+      ]
+    },
+    {
+      "slug": "instruments-markets",
+      "title": {
+        "en": "Instruments & Markets",
+        "pl": "Instrumenty i rynki"
+      },
+      "items": [
+        {
+          "id": "spot",
+          "label": {
+            "en": "Spot Market",
+            "pl": "Rynek Spot"
+          },
+          "description": {
+            "en": "Immediate asset exchange.",
+            "pl": "Natychmiastowa wymiana aktywów."
+          },
+          "tags": [
+            "market",
+            "spot"
+          ],
+          "code": "SpotMarket"
+        },
+        {
+          "id": "perpetual",
+          "label": {
+            "en": "Perpetual Futures",
+            "pl": "Kontrakty Perpetual"
+          },
+          "description": {
+            "en": "Futures without expiry; tied to <a href=\"#funding\">funding rate</a>.",
+            "pl": "Futures bez wygaśnięcia, powiązane z <a href=\"#funding\">fundingiem</a>."
+          },
+          "tags": [
+            "market",
+            "futures"
+          ],
+          "code": "PerpetualFutures"
+        },
+        {
+          "id": "options",
+          "label": {
+            "en": "Options",
+            "pl": "Opcje"
+          },
+          "description": {
+            "en": "Right to buy or sell in future.",
+            "pl": "Prawo do kupna lub sprzedaży w przyszłości."
+          },
+          "tags": [
+            "market",
+            "derivatives"
+          ],
+          "code": "Options"
+        },
+        {
+          "id": "etfs",
+          "label": {
+            "en": "ETFs",
+            "pl": "ETF-y"
+          },
+          "description": {
+            "en": "Exchange-traded funds holding baskets of assets.",
+            "pl": "Fundusze notowane na giełdzie."
+          },
+          "tags": [
+            "market",
+            "etf"
+          ],
+          "code": "ETFs"
+        },
+        {
+          "id": "long",
+          "label": {
+            "en": "Long Position",
+            "pl": "Pozycja Long"
+          },
+          "description": {
+            "en": "Bet on price increase.",
+            "pl": "Zakład na wzrost ceny."
+          },
+          "tags": [
+            "position",
+            "long"
+          ],
+          "code": "LongPosition"
+        },
+        {
+          "id": "short",
+          "label": {
+            "en": "Short Position",
+            "pl": "Pozycja Short"
+          },
+          "description": {
+            "en": "Bet on price decrease.",
+            "pl": "Zakład na spadek ceny."
+          },
+          "tags": [
+            "position",
+            "short"
+          ],
+          "code": "ShortPosition"
+        }
+      ]
+    },
+    {
+      "slug": "quant-ml-in-trading",
+      "title": {
+        "en": "Quant & ML in Trading",
+        "pl": "Kwant i ML w tradingu"
+      },
+      "items": [
+        {
+          "id": "ohlcv",
+          "label": {
+            "en": "OHLCV",
+            "pl": "OHLCV"
+          },
+          "description": {
+            "en": "Candlestick data: open, high, low, close, volume.",
+            "pl": "Dane świecowe: otwarcie, maksimum, minimum, zamknięcie, wolumen."
+          },
+          "tags": [
+            "data",
+            "ohlcv"
+          ],
+          "code": "OHLCV"
+        },
+        {
+          "id": "lstm",
+          "label": {
+            "en": "LSTM",
+            "pl": "LSTM"
+          },
+          "description": {
+            "en": "Recurrent neural network for sequences.",
+            "pl": "Rekurencyjna sieć dla sekwencji czasowych."
+          },
+          "tags": [
+            "ml",
+            "rnn"
+          ],
+          "code": "LSTM"
+        },
+        {
+          "id": "random-forest",
+          "label": {
+            "en": "Random Forest",
+            "pl": "Random Forest"
+          },
+          "description": {
+            "en": "Ensemble of decision trees.",
+            "pl": "Metoda zespołowa drzew decyzyjnych."
+          },
+          "tags": [
+            "ml",
+            "tree"
+          ],
+          "code": "RandomForest"
+        },
+        {
+          "id": "xgboost",
+          "label": {
+            "en": "XGBoost",
+            "pl": "XGBoost"
+          },
+          "description": {
+            "en": "Gradient boosting method.",
+            "pl": "Boosting gradientowy dla danych finansowych."
+          },
+          "tags": [
+            "ml",
+            "boosting"
+          ],
+          "code": "XGBoost"
+        },
+        {
+          "id": "footprint",
+          "label": {
+            "en": "Footprint / CVD",
+            "pl": "Footprint / CVD"
+          },
+          "description": {
+            "en": "Volume and order flow analysis.",
+            "pl": "Analiza wolumenu i przepływu zleceń."
+          },
+          "tags": [
+            "data",
+            "volume"
+          ],
+          "code": "FootprintCVD"
+        }
+      ]
+    },
+    {
+      "slug": "trading-styles",
+      "title": {
+        "en": "Trading Styles",
+        "pl": "Style handlu"
+      },
+      "items": [
+        {
+          "id": "scalping",
+          "label": {
+            "en": "Scalping",
+            "pl": "Scalping"
+          },
+          "description": {
+            "en": "Fast trades for small profits.",
+            "pl": "Szybkie transakcje na małych ruchach."
+          },
+          "tags": [
+            "style",
+            "scalping"
+          ],
+          "code": "Scalping"
+        },
+        {
+          "id": "swing",
+          "label": {
+            "en": "Swing Trading",
+            "pl": "Swing Trading"
+          },
+          "description": {
+            "en": "Holding positions for days or weeks.",
+            "pl": "Przetrzymywanie pozycji od dni do tygodni."
+          },
+          "tags": [
+            "style",
+            "swing"
+          ],
+          "code": "SwingTrading"
+        },
+        {
+          "id": "day-trading",
+          "label": {
+            "en": "Day Trading",
+            "pl": "Day Trading"
+          },
+          "description": {
+            "en": "Closing positions within the day.",
+            "pl": "Zamykanie pozycji w ciągu dnia."
+          },
+          "tags": [
+            "style",
+            "day"
+          ],
+          "code": "DayTrading"
+        },
+        {
+          "id": "position-trading",
+          "label": {
+            "en": "Position Trading",
+            "pl": "Position Trading"
+          },
+          "description": {
+            "en": "Long-term investing.",
+            "pl": "Długoterminowe inwestowanie."
+          },
+          "tags": [
+            "style",
+            "position"
+          ],
+          "code": "PositionTrading"
+        }
+      ]
+    },
+    {
+      "slug": "bybit-binance-terms",
+      "title": {
+        "en": "Bybit/Binance Terms",
+        "pl": "Terminy specyficzne dla Bybit/Binance"
+      },
+      "items": [
+        {
+          "id": "funding",
+          "label": {
+            "en": "Funding Rate",
+            "pl": "Funding Rate"
+          },
+          "description": {
+            "en": "Payment aligning <a href=\"#perpetual\">perpetual futures</a> price with spot.",
+            "pl": "Mechanizm wyrównujący cenę <a href=\"#perpetual\">perpetuals</a> do spotu."
+          },
+          "tags": [
+            "exchange",
+            "funding"
+          ],
+          "code": "FundingRate"
+        },
+        {
+          "id": "margin",
+          "label": {
+            "en": "Margin",
+            "pl": "Margin"
+          },
+          "description": {
+            "en": "Collateral securing leveraged trades.",
+            "pl": "Kapitał zabezpieczający pozycję."
+          },
+          "tags": [
+            "exchange",
+            "margin"
+          ],
+          "code": "Margin"
+        },
+        {
+          "id": "pnl",
+          "label": {
+            "en": "PnL",
+            "pl": "PnL"
+          },
+          "description": {
+            "en": "Profit and loss, realized or unrealized.",
+            "pl": "Zysk i strata (zrealizowana/niezrealizowana)."
+          },
+          "tags": [
+            "exchange",
+            "pnl"
+          ],
+          "code": "PnL"
+        },
+        {
+          "id": "liquidation",
+          "label": {
+            "en": "Liquidation",
+            "pl": "Liquidacja"
+          },
+          "description": {
+            "en": "Forced closing due to insufficient <a href=\"#margin\">margin</a>.",
+            "pl": "Przymusowe zamknięcie z powodu braku <a href=\"#margin\">marginu</a>."
+          },
+          "tags": [
+            "exchange",
+            "liquidation"
+          ],
+          "code": "Liquidation"
+        }
+      ]
     }
   ]
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -120,6 +120,16 @@ body {
     border-radius: 8px;
     padding: 0.5em 1em;
     background: #fafafa;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.glossary-card h4 {
+    margin-top: 0;
+    margin-bottom: 0.5em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    border-bottom: 1px dashed #bbb;
+    padding-bottom: 0.25em;
 }
 
 .glossary-card .tags,
@@ -127,6 +137,37 @@ body {
     display: block;
     font-size: 0.9em;
     color: #555;
+}
+
+.glossary-section {
+    margin-top: 2em;
+    padding-top: 1em;
+    border-top: 3px double #bbb;
+    position: relative;
+}
+
+.glossary-section:first-of-type {
+    border-top: none;
+    padding-top: 0;
+}
+
+.glossary-section h3 {
+    margin: 0 0 0.75em;
+    font-size: 1.1em;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    border-bottom: 2px solid #ccc;
+    padding-bottom: 0.3em;
+}
+
+.glossary-section::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -0.75em;
+    height: 1px;
+    background: repeating-linear-gradient(90deg, transparent, transparent 8px, #ddd 8px, #ddd 16px);
 }
 
 .tags .tag {


### PR DESCRIPTION
## Summary
- add a helper to the generator so sections are written with indentation and blank lines for easier editing
- refresh the bilingual home-introduction copy with clearer spacing and corrected wording
- regenerate the English and Polish index pages to use the new multiline layout throughout the navigation and content blocks

## Testing
- python generate.py

------
https://chatgpt.com/codex/tasks/task_e_68d1a28384708329aaf88f53b7fba78f